### PR TITLE
Iterate delegates using a copy

### DIFF
--- a/MultiDelegate/AIMultiDelegate.m
+++ b/MultiDelegate/AIMultiDelegate.m
@@ -68,7 +68,7 @@
 - (BOOL)respondsToSelector:(SEL)selector {
     if ([super respondsToSelector:selector])
         return YES;
-    
+
     for (id delegate in _delegates) {
         if (delegate && [delegate respondsToSelector:selector])
             return YES;
@@ -87,7 +87,7 @@
         // return any method signature, it doesn't really matter
         return [self methodSignatureForSelector:@selector(description)];
     }
-    
+
     for (id delegate in _delegates) {
         if (!delegate)
             continue;
@@ -104,7 +104,8 @@
     SEL selector = [invocation selector];
     BOOL responded = NO;
     
-    for (id delegate in _delegates) {
+    NSArray *copiedDelegates = [_delegates copy];
+    for (id delegate in copiedDelegates) {
         if (delegate && [delegate respondsToSelector:selector]) {
             [invocation invokeWithTarget:delegate];
             responded = YES;


### PR DESCRIPTION
This is to prevent possible crashes if the delegates array is modified
during iteration.
